### PR TITLE
Add augmentation config and dataset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,20 @@ The encoded features go through a stack of optional, configurable layers:
 - Frame-level BIO tag training
 - Configurable architecture (BiLSTM, Conformer, Conv)
 - HTK-compatible `.lab` output format
+- Optional waveform augmentation via the `augmentation` config section
 
 ---
+
+## Augmentation Options
+
+The `config.yaml` file now includes an optional `augmentation` section used during training. When enabled it randomly applies volume scaling and Gaussian noise:
+
+```yaml
+augmentation:
+  enable: true
+  noise_std: 0.005      # standard deviation of Gaussian noise
+  prob: 0.5             # probability to augment a sample
+  volume_range: [0.9, 1.1]  # random scaling of audio volume
+```
+
+Disable augmentation by setting `enable: false`.

--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,12 @@ training:
   max_checkpoints: 5
   log_dir: "/content/drive/MyDrive/WFL_13_mel_20ms/logs" # path to logs folder for tensorboard
 
+augmentation:
+  enable: true
+  noise_std: 0.005
+  prob: 0.5
+  volume_range: [0.9, 1.1]
+
 finetuning:
   enable: false # enabling WLF finetuning
   model_path: null # path to finetune model


### PR DESCRIPTION
## Summary
- extend `config.yaml` with waveform augmentation options
- implement augmentation logic in `PhonemeDataset`
- pass augmentation config when creating the dataset
- document augmentation usage in `README`

## Testing
- `python -m py_compile train.py`
- `python -m py_compile model.py utils.py correct_label.py preprocess.py infer.py`

------
https://chatgpt.com/codex/tasks/task_e_683f9cd4b2688331bcebb83c7f267310